### PR TITLE
wq/fix autocompare when compared value is nan

### DIFF
--- a/op_tools/op_autocompare_hook.py
+++ b/op_tools/op_autocompare_hook.py
@@ -1,4 +1,5 @@
 import torch
+import math
 from .base_hook import BaseHook, DisableHookGuard
 from .utils import to_device, is_cpu_op
 from .op_fallback_hook import OpFallbackHook
@@ -19,7 +20,7 @@ def tensor_max_diff(a, b):
 def tensor_allclose(a, b, atol=1e-3, rtol=1e-3):
     a_cpu, b_cpu = a.cpu(), b.cpu()
     try:
-        return torch.allclose(a_cpu, b_cpu, atol=atol, rtol=rtol)
+        return torch.allclose(a_cpu, b_cpu, atol=atol, rtol=rtol, equal_nan=True)
     except Exception as e:
         return False
     return False
@@ -43,7 +44,7 @@ def compare_result(name, a, b, atol=1e-3):
             f"OpAutoCompareHook: {name:<50} allclose: {allclose}\tmax_diff: {f'{max_diff:20.9f}'} {error_info}"
         )
     elif isinstance(a, (bool, int, float)):
-        allclose = a == b
+        allclose = a == b or (math.isnan(a) and math.isnan(b))
         max_diff = a - b
         print(
             f"OpAutoCompareHook: {name:<50} allclose: {allclose}\tmax_diff: {f'{max_diff:20.9f}'}"
@@ -66,7 +67,7 @@ def compare_result(name, a, b, atol=1e-3):
                     f"OpAutoCompareHook: {name:<46} {i}th allclose: {allclose_i}\tmax_diff: {f'{max_diff_i:20.9f}'} {error_info_i}"
                 )
             else:
-                allclose_i = a[i] == b[i]
+                allclose_i = a[i] == b[i] or (math.isnan(a[i]) and math.isnan(b[i]))
                 max_diff_i = a[i] - b[i]
                 max_diff_list.append(max_diff_i)
                 allclose_list.append(allclose_i)


### PR DESCRIPTION
## 起因
在A+K机器上，使用ditorch的autocompare功能验证llama2-7B的精度时，遇到nan
```bash
OpAutoCompareHook: torch.Tensor.div                                   allclose: False    max_diff:                  nan 
OpAutoCompareHook: torch.Tensor.item                                  allclose: False    max_diff:                  nan
OpAutoCompareHook: torch.Tensor.item                                  allclose: True    max_diff:          0.000000000
OpAutoCompareHook: torch.Tensor.div                                   allclose: False    max_diff:                  nan 
OpAutoCompareHook: torch.Tensor.item                                  allclose: False    max_diff:                  nan
OpAutoCompareHook: torch.Tensor.div                                   allclose: False    max_diff:                  nan 
OpAutoCompareHook: torch.Tensor.fill_                                 allclose: True    max_diff:          0.000000000 
OpAutoCompareHook: torch.Tensor.item                                  allclose: False    max_diff:                  nan
OpAutoCompareHook: torch.Tensor.fill_                                 allclose: True    max_diff:          0.000000000 
OpAutoCompareHook: torch.Tensor.div                                   allclose: False    max_diff:                  nan 
OpAutoCompareHook: torch.Tensor.fill_                                 allclose: True    max_diff:          0.000000000 
OpAutoCompareHook: torch.Tensor.item                                  allclose: False    max_diff:                  nan
```

## 排查
于是将div和item的输入输出保存在本地，加载打印如下：
```bash
# div
{'name': 'torch.Tensor.div', 'args': (tensor(0.), tensor(0.)), 'kwargs': {}, 'identifier': 'cpu/input'}
{'name': 'torch.Tensor.div', 'args': (tensor(nan),), 'kwargs': {}, 'identifier': 'cpu/output'}

# item
{'name': 'torch.Tensor.item', 'args': (tensor(nan),), 'kwargs': {}, 'identifier': 'cpu/input'}
{'name': 'torch.Tensor.item', 'args': (nan,), 'kwargs': {}, 'identifier': 'cpu/output'}
```
发现cpu的input也为0，0/0出现nan；于是item的input和output也变成nan

## 解决
compare_result中缺少对nan比较的特殊处理，验证如下：
```python
Python 3.9.18 (main, Sep 11 2023, 13:51:18) 
[GCC 11.2.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
# inf不用特判
>>> a = float("inf")
>>> b = float("inf")
>>> a == b
True

# nan不能直接比较，需要用math.isnan
>>> b = float("nan")
>>> a = float("nan")
>>> a == b
False
>>> import math
>>> math.isnan(a)
True

# 对于含有nan的tesnor，torch.allclose提供了参数来控制
>>> import torch
>>> a = torch.tensor(float("nan"))
>>> b = torch.tensor(float("nan"))
>>> torch.allclose(a, b, atol=0.001, rtol=0.001)
False
>>> torch.allclose(a, b, atol=0.001, rtol=0.001, equal_nan=True)
True
```