### PR TITLE
add torch.rand_like to autocompare blacklist

### DIFF
--- a/op_tools/op_autocompare_hook.py
+++ b/op_tools/op_autocompare_hook.py
@@ -34,6 +34,7 @@ RANDOM_NUMBER_GEN_OPS = [
     "torch.Tensor.multinomial",
     "torch.rand",
     "torch.randperm",
+    "torch.rand_like",
     "torch.bernoulli",
     "torch.poisson",
     "torch.randint_like",


### PR DESCRIPTION
随机数生成算子不应该做精度对比，之前遗漏了torch.rand_like，在测试中报allclose False