### PR TITLE
Zgc/ditorch enhance autocompare

### DIFF
--- a/op_tools/op_autocompare_hook.py
+++ b/op_tools/op_autocompare_hook.py
@@ -14,48 +14,12 @@ from .utils import (
     is_view_op,
     is_opname_match,
     compare_result,
+    is_random_number_gen_op,
 )
 from .save_op_args import save_op_args, serialize_args_to_dict
 
 from .pretty_print import pretty_print_op_args, dict_data_list_to_table
 
-RANDOM_NUMBER_GEN_OPS = [
-    "torch.Tensor.random_",
-    "torch.Tensor.uniform_",
-    "torch.Tensor.normal_",
-    "torch.Tensor.bernoulli_",
-    "torch.Tensor.poisson_",
-    "torch.Tensor.multinomial_",
-    "torch.Tensor.random",
-    "torch.Tensor.uniform",
-    "torch.Tensor.normal",
-    "torch.Tensor.bernoulli",
-    "torch.Tensor.poisson",
-    "torch.Tensor.multinomial",
-    "torch.rand",
-    "torch.randperm",
-    "torch.bernoulli",
-    "torch.poisson",
-    "torch.randint_like",
-    "torch.randint",
-    "torch.randn",
-    "torch.randn_like",
-    "torch.multinomial",
-    "torch.nn.init.kaiming_uniform",
-    "torch.nn.init.kaiming_uniform_",
-    "torch.nn.init.trunc_normal_",
-    "torch.nn.init.uniform",
-    "torch.nn.init.normal",
-    "torch.nn.init.uniform_",
-    "torch.nn.init.normal_",
-    "torch.nn.init.warnings",
-    "torch.nn.init.xavier_normal",
-    "torch.nn.init.xavier_normal_",
-    "torch.nn.init.xavier_uniform",
-    "torch.nn.init.kaiming_normal",
-    "torch.nn.init.xavier_uniform_",
-    "torch.nn.init.kaiming_normal_",
-]
 
 SKIP_LIST_OPS = []
 
@@ -75,18 +39,6 @@ class BackwardHookHandle:
         hook_handle = tensor.grad_fn.register_hook(grad_fun)
         return grad_fun
 
-    def register_tensor_hook(self, index, tensor):
-        hook_handle = None
-
-        def grad_fun(grad):
-            self.compare_hook.set_input_grad(index, grad)
-            self.compare_hook.compare_all_grad()
-            hook_handle.remove()
-
-        hook_handle = tensor.register_hook(grad_fun)
-
-        return grad_fun
-
 
 global_autocompare_result = []
 
@@ -100,104 +52,54 @@ class OpAutoCompareHook(BaseHook):
     def __init__(self, name, func) -> None:
         super().__init__(name, func)
 
-    def before_call_op(self, *args, **kwargs):
-        self.forward_op_id = self.id
-        self.identifier = f"autocompare/{self.id}/{time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())}"
-        with DisableHookGuard():
-            self.is_cpu_op, self.device = is_cpu_op(*args, **kwargs)
-            if self.is_cpu_op:
-                return
+    def copy_input_to_cpu(self):
+        self.args_cpu = to_device(
+            "cpu",
+            self.args,
+            detach=True,
+        )
+        self.kwargs_cpu = to_device(
+            "cpu",
+            self.kwargs or {},
+            detach=True,
+        )
+
+    def run_forward_on_cpu(self):
+        try:
+            self.result_cpu = self.func(*self.args_cpu, **self.kwargs_cpu)
+            self.result_device = to_device("cpu", self.result, detach=True)
+            self.dtype_cast_dict = dict()
+            args_cpu = self.args_cpu
+        except Exception as e:  # noqa: F841
+            self.dtype_cast_dict = OpAutoCompareHook.AUTO_COMPARE_DTYPE_CAST_DICT
+            # some op on cpu backend not support half, bfloat16
             self.args_cpu = to_device(
                 "cpu",
-                self.args,
+                self.args_cpu,
+                dtype_cast_dict=self.dtype_cast_dict,
                 detach=True,
             )
             self.kwargs_cpu = to_device(
                 "cpu",
-                self.kwargs or {},
+                self.kwargs_cpu or {},
+                dtype_cast_dict=self.dtype_cast_dict,
                 detach=True,
             )
-
-    def after_call_op(self, result):  # noqa:C901
-        if self.is_cpu_op:
-            return
-        with DisableHookGuard():
-            self.result = result
-            try:
-                self.result_cpu = self.func(*self.args_cpu, **self.kwargs_cpu)
-                self.result_device = to_device("cpu", self.result, detach=True)
-                self.dtype_cast_dict = dict()
+            # RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
+            if (is_inplace_op(self.name) or is_view_op(self.name)) and self.args[0].requires_grad:
+                args_cpu = [item for item in self.args_cpu]
+                args_cpu[0] = args_cpu[0].clone()
+                self.result_cpu = self.func(*args_cpu, **self.kwargs_cpu)
+            else:
                 args_cpu = self.args_cpu
-            except Exception as e:  # noqa: F841
-                self.dtype_cast_dict = OpAutoCompareHook.AUTO_COMPARE_DTYPE_CAST_DICT
-                # some op on cpu backend not support half, bfloat16
-                self.args_cpu = to_device(
-                    "cpu",
-                    self.args_cpu,
-                    dtype_cast_dict=self.dtype_cast_dict,
-                    detach=True,
-                )
-                self.kwargs_cpu = to_device(
-                    "cpu",
-                    self.kwargs_cpu or {},
-                    dtype_cast_dict=self.dtype_cast_dict,
-                    detach=True,
-                )
-                # RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
-                if (is_inplace_op(self.name) or is_view_op(self.name)) and self.args[0].requires_grad:
-                    args_cpu = [item for item in self.args_cpu]
-                    args_cpu[0] = args_cpu[0].clone()
-                    self.result_cpu = self.func(*args_cpu, **self.kwargs_cpu)
-                else:
-                    args_cpu = self.args_cpu
-                    self.result_cpu = self.func(*self.args_cpu, **self.kwargs_cpu)
+                self.result_cpu = self.func(*self.args_cpu, **self.kwargs_cpu)
 
-                self.result_device = to_device(
-                    "cpu",
-                    self.result,
-                    dtype_cast_dict=self.dtype_cast_dict,
-                    detach=True,
-                )
-
-            if is_inplace_op(self.name):
-                compare_info = compare_result(self.name, self.args[0], args_cpu[0])
-                allclose = compare_info["allclose"]
-                if not allclose:
-                    self.save_forward_args()
-                compare_info.update({"forward_id": self.forward_op_id})
-                global_autocompare_result.append(compare_info)
-
-            compare_info = compare_result(self.name, self.result_device, self.result_cpu)
-            compare_info.update({"forward_id": self.forward_op_id})
-            global_autocompare_result.append(compare_info)
-            allclose = compare_info["allclose"]
-
-            if self.result is None:
-                print(f"{self.name} output is None, acc not checked")
-                return
-
-            self.forward_allclose = allclose
-            if not allclose:
-                pretty_print_op_args(
-                    self.name,
-                    serialize_args_to_dict(*self.args, **self.kwargs),
-                    serialize_args_to_dict(self.result),
-                )
-                self.save_forward_args()
-
-            self.backward_hook_handle = BackwardHookHandle(self)
-            for result in traverse_container(self.result):
-                if isinstance(result, torch.Tensor):
-                    if result.grad_fn is not None:
-                        self.backward_hook_handle.register_grad_fn_hook(result)
-            index = -1
-            for arg in traverse_container(self.args):
-                index += 1
-                if isinstance(arg, torch.Tensor) and arg.requires_grad:
-                    self.backward_hook_handle.register_tensor_hook(index, arg)
-
-            self.args = to_device("cpu", self.args, detach=True)
-            self.kwargs = to_device("cpu", self.kwargs or {}, detach=True)
+            self.result_device = to_device(
+                "cpu",
+                self.result,
+                dtype_cast_dict=self.dtype_cast_dict,
+                detach=True,
+            )
 
     def run_backward_on_cpu(self, grad_inputs, grad_output):
         self.grad_outputs_cpu = to_device("cpu", grad_output, dtype_cast_dict=self.dtype_cast_dict, detach=True)
@@ -206,16 +108,37 @@ class OpAutoCompareHook(BaseHook):
             if isinstance(arg_cpu, torch.Tensor) and arg_cpu.grad is not None:
                 arg_cpu.grad.zero_()
 
+        self.args_cpu_grad = []
+
+        def post_hook(grad_inputs, grad_outputs):
+            self.args_cpu_grad = [grad_input for grad_input in grad_inputs]
+
         for result_cpu in traverse_container(self.result_cpu):
             if isinstance(result_cpu, torch.Tensor) and result_cpu.requires_grad:
+                handle = result_cpu.grad_fn.register_hook(post_hook)
                 result_cpu.backward(*self.grad_outputs_cpu)
+                handle.remove()
 
-        self.args_cpu_grad = []
-        for i in range(len(self.args_cpu)):
-            if isinstance(self.args_cpu[i], torch.Tensor) and self.args_cpu[i].grad is not None:
-                self.args_cpu_grad.append(self.args_cpu[i].grad)
-            else:
-                self.args_cpu_grad.append(None)
+    def register_backward_hook_for_grads(self):
+        self.backward_hook_handle = BackwardHookHandle(self)
+        for result in traverse_container(self.result):
+            if isinstance(result, torch.Tensor):
+                if result.grad_fn is not None:
+                    self.backward_hook_handle.register_grad_fn_hook(result)
+
+    def compare_forward_result(self):
+        compare_info = compare_result(self.name, self.result_device, self.result_cpu)
+        compare_info.update({"forward_id": self.forward_op_id})
+        global_autocompare_result.append(compare_info)
+        allclose = compare_info["allclose"]
+        self.forward_allclose = allclose
+        if not allclose:
+            pretty_print_op_args(
+                self.name,
+                serialize_args_to_dict(*self.args, **self.kwargs),
+                serialize_args_to_dict(self.result),
+            )
+            self.save_forward_args()
 
     def count_params_with_requires_grad(self):
         count = 0
@@ -225,29 +148,8 @@ class OpAutoCompareHook(BaseHook):
         return count
 
     def compare_all_grad(self):
-        """
-        Since the order in which the two backward hooks registered by different operators \
-        are called is not exactly the same, and the gradient can only be calculated on the CPU \
-        after the grad_fn hook is called, there is a judgment here, \
-        because only when the gradient on the CPU is calculated \
-        and all the gradients of the device parameters are obtained, \
-        can the gradient information be compared.
-        """
-        if not hasattr(self, "args_cpu_grad"):
-            return
-        if not hasattr(self, "args_grad"):
-            return
-
-        # Check if all gradients have been obtained
-        for i in range(len(self.args)):
-            arg = self.args[i]
-            if isinstance(arg, torch.Tensor) and (arg.requires_grad and self.args_grad[i] is None):
-                return
-        # For leaf nodes, their grad_fn is None, so their gradients can only be obtained through torch.Tensor.register_hook
-        if self.count_params_with_requires_grad() != len(self.args_grad):
-            compare_info = compare_result(self.name + " grad", self.args_cpu_grad, self.args_grad)
-        else:
-            compare_info = compare_result(self.name + " grad", self.args_cpu_grad, self.grad_inputs_cpu)
+        self.args_grad = self.grad_inputs_cpu
+        compare_info = compare_result(self.name + " grad", self.args_cpu_grad, self.args_grad)
 
         compare_info.update({"forward_id": self.forward_op_id})
         global_autocompare_result.append(compare_info)
@@ -258,11 +160,6 @@ class OpAutoCompareHook(BaseHook):
             self.save_backward_args()
         self = None
         gc.collect()
-
-    def set_input_grad(self, index, grad):
-        if not hasattr(self, "args_grad"):
-            self.args_grad = [None for i in range(len(self.args))]
-        self.args_grad[index] = to_device("cpu", grad, dtype_cast_dict=self.dtype_cast_dict, detach=True)
 
     def save_forward_args(self):
         save_op_args(
@@ -302,8 +199,34 @@ class OpAutoCompareHook(BaseHook):
             *tuple(self.grad_outputs_cpu),
         )
 
+    def before_call_op(self, *args, **kwargs):
+        self.forward_op_id = self.id
+        self.identifier = f"autocompare/{self.id}/{time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())}"
+        with DisableHookGuard():
+            self.is_cpu_op, self.device = is_cpu_op(*args, **kwargs)
+            if self.is_cpu_op:
+                return
+            self.copy_input_to_cpu()
+
+    def after_call_op(self, result):  # noqa:C901
+        if self.is_cpu_op:
+            return
+        with DisableHookGuard():
+            self.run_forward_on_cpu()
+
+            if self.result is None and self.result_cpu is None:
+                print(f"{self.name} output is None, no check for accuracy")
+                return
+
+            self.compare_forward_result()
+
+            self.register_backward_hook_for_grads()
+
+            self.args = to_device("cpu", self.args, detach=True)
+            self.kwargs = to_device("cpu", self.kwargs or {}, detach=True)
+
     def is_should_apply(self, *args, **kwargs):
-        if self.name in RANDOM_NUMBER_GEN_OPS:
+        if is_random_number_gen_op(self.name):
             return False
 
         if self.name in SKIP_LIST_OPS:

--- a/op_tools/op_autocompare_hook.py
+++ b/op_tools/op_autocompare_hook.py
@@ -243,8 +243,12 @@ class OpAutoCompareHook(BaseHook):
             arg = self.args[i]
             if isinstance(arg, torch.Tensor) and (arg.requires_grad and self.args_grad[i] is None):
                 return
+        # For leaf nodes, their grad_fn is None, so their gradients can only be obtained through torch.Tensor.register_hook
+        if self.count_params_with_requires_grad() != len(self.args_grad):
+            compare_info = compare_result(self.name + " grad", self.args_cpu_grad, self.args_grad)
+        else:
+            compare_info = compare_result(self.name + " grad", self.args_cpu_grad, self.grad_inputs_cpu)
 
-        compare_info = compare_result(self.name + " grad", self.args_cpu_grad, self.args_grad)
         compare_info.update({"forward_id": self.forward_op_id})
         global_autocompare_result.append(compare_info)
         if not compare_info["allclose"]:

--- a/op_tools/test/test_compare_result.py
+++ b/op_tools/test/test_compare_result.py
@@ -102,9 +102,7 @@ class TestCompareResult(unittest.TestCase):
             compare_info = compare_result("different_int", result1, result2)
             self.assertTrue(compare_info["allclose"] is False)
             self.assertTrue(compare_info["max_abs_diff"] == i + 10)
-            self.assertTrue(
-                abs(compare_info["max_relative_diff"] - ((i + 10) / i)) < 1e-3
-            )
+            self.assertTrue(abs(compare_info["max_relative_diff"] - ((i + 10) / i)) < 1e-3)
             self.assertTrue(isinstance(compare_info["result_list"], list))
 
     def test_compare_same_float(self):
@@ -124,9 +122,7 @@ class TestCompareResult(unittest.TestCase):
             compare_info = compare_result("different_float", result1, result2)
             self.assertTrue(compare_info["allclose"] is False)
             self.assertTrue(compare_info["max_abs_diff"] == i + 10)
-            self.assertTrue(
-                abs(compare_info["max_relative_diff"] - ((i + 10) / i)) < 1e-3
-            )
+            self.assertTrue(abs(compare_info["max_relative_diff"] - ((i + 10) / i)) < 1e-3)
             self.assertTrue(isinstance(compare_info["result_list"], list))
 
     def test_compare_same_bool(self):

--- a/op_tools/test/test_custom_apply_hook.py
+++ b/op_tools/test/test_custom_apply_hook.py
@@ -49,15 +49,9 @@ def _test_function(x, y):
 
 class TestCustomApplyHook(unittest.TestCase):
     def test_fallback_op(self):
-        op_tools.apply_feature(
-            ops=["torch.add", "torch.sub", "torch.mul", "torch.div"], feature="fallback"
-        )
-        x = torch.tensor(
-            [1, 2, 3], dtype=torch.float16, device="cuda", requires_grad=True
-        )
-        y = torch.tensor(
-            [4, 5, 6], dtype=torch.float16, device="cuda", requires_grad=True
-        )
+        op_tools.apply_feature(ops=["torch.add", "torch.sub", "torch.mul", "torch.div"], feature="fallback")
+        x = torch.tensor([1, 2, 3], dtype=torch.float16, device="cuda", requires_grad=True)
+        y = torch.tensor([4, 5, 6], dtype=torch.float16, device="cuda", requires_grad=True)
         _test_function(x, y)
 
     def test_dump_all_args(self):
@@ -65,12 +59,8 @@ class TestCustomApplyHook(unittest.TestCase):
             ops=["torch.add", "torch.sub", "torch.mul", "torch.div"],
             feature="dump_op_args",
         )
-        x = torch.tensor(
-            [1, 2, 3], dtype=torch.float16, device="cuda", requires_grad=True
-        )
-        y = torch.tensor(
-            [4, 5, 6], dtype=torch.float16, device="cuda", requires_grad=True
-        )
+        x = torch.tensor([1, 2, 3], dtype=torch.float16, device="cuda", requires_grad=True)
+        y = torch.tensor([4, 5, 6], dtype=torch.float16, device="cuda", requires_grad=True)
 
         _test_function(x, y)
 
@@ -79,12 +69,8 @@ class TestCustomApplyHook(unittest.TestCase):
             ops=["torch.add", "torch.sub", "torch.mul", "torch.div"],
             feature="op_capture",
         )
-        x = torch.tensor(
-            [1, 2, 3], dtype=torch.float16, device="cuda", requires_grad=True
-        )
-        y = torch.tensor(
-            [4, 5, 6], dtype=torch.float16, device="cuda", requires_grad=True
-        )
+        x = torch.tensor([1, 2, 3], dtype=torch.float16, device="cuda", requires_grad=True)
+        y = torch.tensor([4, 5, 6], dtype=torch.float16, device="cuda", requires_grad=True)
 
         _test_function(x, y)
 
@@ -93,12 +79,8 @@ class TestCustomApplyHook(unittest.TestCase):
             ops=["torch.add", "torch.sub", "torch.mul", "torch.div"],
             feature="measure_op_time",
         )
-        x = torch.tensor(
-            [1, 2, 3], device="cuda", dtype=torch.float16, requires_grad=True
-        )
-        y = torch.tensor(
-            [4, 5, 6], device="cuda", dtype=torch.float16, requires_grad=True
-        )
+        x = torch.tensor([1, 2, 3], device="cuda", dtype=torch.float16, requires_grad=True)
+        y = torch.tensor([4, 5, 6], device="cuda", dtype=torch.float16, requires_grad=True)
         _test_function(x, y)
 
     def test_cast_dtype(self):
@@ -124,20 +106,12 @@ class TestCustomApplyHook(unittest.TestCase):
             feature="dump_op_args",
             condition_func=condition_func,
         )
-        x = torch.tensor(
-            [1, 2, 3], dtype=torch.float16, device="cuda", requires_grad=True
-        )
-        y = torch.tensor(
-            [4, 5, 6], dtype=torch.float16, device="cuda", requires_grad=True
-        )
+        x = torch.tensor([1, 2, 3], dtype=torch.float16, device="cuda", requires_grad=True)
+        y = torch.tensor([4, 5, 6], dtype=torch.float16, device="cuda", requires_grad=True)
         _test_function(x, y)
 
-        x = torch.tensor(
-            [1, 2, 3], dtype=torch.float32, device="cuda", requires_grad=True
-        )
-        y = torch.tensor(
-            [4, 5, 6], dtype=torch.float32, device="cuda", requires_grad=True
-        )
+        x = torch.tensor([1, 2, 3], dtype=torch.float32, device="cuda", requires_grad=True)
+        y = torch.tensor([4, 5, 6], dtype=torch.float32, device="cuda", requires_grad=True)
         _test_function(x, y)
 
     def test_condition_autocompare(self):
@@ -157,18 +131,10 @@ class TestCustomApplyHook(unittest.TestCase):
                 print(f"not autocompare beacuse input dim is {a.dim()}")
                 return False
 
-        op_tools.apply_feature(
-            "torch.add", feature="autocompare", condition_func=condition_func1
-        )
-        op_tools.apply_feature(
-            "torch.sub", feature="autocompare", condition_func=condition_func2
-        )
-        op_tools.apply_feature(
-            "torch.mul", feature="autocompare", condition_func=condition_func1
-        )
-        op_tools.apply_feature(
-            "torch.div", feature="autocompare", condition_func=condition_func2
-        )
+        op_tools.apply_feature("torch.add", feature="autocompare", condition_func=condition_func1)
+        op_tools.apply_feature("torch.sub", feature="autocompare", condition_func=condition_func2)
+        op_tools.apply_feature("torch.mul", feature="autocompare", condition_func=condition_func1)
+        op_tools.apply_feature("torch.div", feature="autocompare", condition_func=condition_func2)
 
         x = torch.randn(3, 4, dtype=torch.float16, device="cuda", requires_grad=True)
         y = torch.randn(3, 4, dtype=torch.float16, device="cuda", requires_grad=True)
@@ -177,6 +143,17 @@ class TestCustomApplyHook(unittest.TestCase):
         x = torch.randn(3, 4, dtype=torch.float32, device="cuda", requires_grad=True)
         y = torch.randn(3, 4, dtype=torch.float32, device="cuda", requires_grad=True)
         _test_function(x, y)
+
+    def test_condition_autocompare_linear(self):
+        device = torch.device("cuda")
+        input = torch.randn(20, 30, requires_grad=True).to(device)
+        weight = torch.randn(40, 30, requires_grad=True, device=device)
+        bias = torch.randn(40, requires_grad=True, device=device)
+
+        op_tools.apply_feature("torch.nn.functional.linear", feature="autocompare")
+        func = torch.nn.functional.linear
+        out = func(input, weight, bias)
+        out.sum().backward()
 
 
 if __name__ == "__main__":

--- a/op_tools/test/test_custom_condition_to_enable_hook_example.py
+++ b/op_tools/test/test_custom_condition_to_enable_hook_example.py
@@ -23,19 +23,13 @@ z = torch.randn(2, 3, 4, dtype=torch.float).cuda()
 op_tools.apply_feature("torch.add", feature="fallback", condition_func=custom_condition)
 torch.add(x, x)
 
-op_tools.apply_feature(
-    "torch.sub", feature="autocompare", condition_func=custom_condition
-)
+op_tools.apply_feature("torch.sub", feature="autocompare", condition_func=custom_condition)
 torch.sub(y, y)
 torch.sub(z, z)
 
-op_tools.apply_feature(
-    "torch.mul", feature="op_capture", condition_func=custom_condition
-)
+op_tools.apply_feature("torch.mul", feature="op_capture", condition_func=custom_condition)
 torch.mul(x, x)
 
-op_tools.apply_feature(
-    "torch.div", feature="cast_dtype", condition_func=custom_condition
-)
+op_tools.apply_feature("torch.div", feature="cast_dtype", condition_func=custom_condition)
 os.environ["OP_DTYPE_CAST_DICT"] = "torch.float32->torch.float16"
 torch.div(y, y)

--- a/op_tools/test/test_embedding.py
+++ b/op_tools/test/test_embedding.py
@@ -15,9 +15,7 @@ class TestEmbedding(unittest.TestCase):
             embedding = nn.Embedding(n, d, max_norm=True, device="cuda")
             W = torch.randn((m, d), requires_grad=True, device="cuda")
             idx = torch.tensor([1, 2]).cuda()
-            a = (
-                embedding.weight.clone() @ W.t()
-            )  # weight must be cloned for this to be differentiable
+            a = embedding.weight.clone() @ W.t()  # weight must be cloned for this to be differentiable
             b = embedding(idx) @ W.t()  # modifies weight in-place
             out = a.unsqueeze(0) + b.unsqueeze(1)
             loss = out.sigmoid().prod()

--- a/op_tools/test/test_event.py
+++ b/op_tools/test/test_event.py
@@ -9,12 +9,8 @@ class TestEvent(unittest.TestCase):
     def test_event_measure_device_time(self):
         x = torch.randn(3, 4).cuda()
 
-        start_event = torch.cuda.Event(
-            enable_timing=True, blocking=False, interprocess=False
-        )
-        end_event = torch.cuda.Event(
-            enable_timing=True, blocking=False, interprocess=False
-        )
+        start_event = torch.cuda.Event(enable_timing=True, blocking=False, interprocess=False)
+        end_event = torch.cuda.Event(enable_timing=True, blocking=False, interprocess=False)
 
         start_event.record(torch.cuda.current_stream())
 

--- a/op_tools/test/test_op_autocompare.py
+++ b/op_tools/test/test_op_autocompare.py
@@ -7,13 +7,7 @@ import op_tools
 
 def f():
     a = torch.rand(10, requires_grad=True, device="cuda").half()
-    a = (
-        torch.bernoulli(a)
-        + a
-        + torch.rand_like(a)
-        + torch.empty_like(a).uniform_()
-        + torch.empty_like(a).normal_()
-    )
+    a = torch.bernoulli(a) + a + torch.rand_like(a) + torch.empty_like(a).uniform_() + torch.empty_like(a).normal_()
     b = a * 2 + torch.randperm(a.numel(), dtype=a.dtype, device=a.device).view(a.shape)
     c = b + a
     d = c - a

--- a/op_tools/test/test_op_dtype_cast.py
+++ b/op_tools/test/test_op_dtype_cast.py
@@ -46,9 +46,7 @@ dtype_caster.stop()
 # usage4
 os.environ["OP_DTYPE_CAST_DISABLE_LIST"] = ""
 os.environ["OP_DTYPE_CAST_LIST"] = "torch.Tensor.sort"  # only cast this op
-os.environ["OP_DTYPE_CAST_DICT"] = (
-    "torch.half->torch.float32"  # camb 370 not support bfloat16
-)
+os.environ["OP_DTYPE_CAST_DICT"] = "torch.half->torch.float32"  # camb 370 not support bfloat16
 dtype_caster.start()
 f()
 dtype_caster.stop()

--- a/op_tools/test/test_op_fallback.py
+++ b/op_tools/test/test_op_fallback.py
@@ -21,9 +21,7 @@ def f():
 
     base = 10000
     dim = 1024
-    inv_freq = 1.0 / (
-        base ** (torch.arange(0, dim, 2, device="cuda", dtype=torch.float32) / dim)
-    )
+    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, device="cuda", dtype=torch.float32) / dim))
 
     x = torch.randn(3, 4).cuda().to(torch.float16)  # camb_mlu370 not support bfloat16
     y = x.clone()

--- a/op_tools/test/test_op_tools.py
+++ b/op_tools/test/test_op_tools.py
@@ -124,13 +124,9 @@ class TestOpTools(unittest.TestCase):
         input = torch.ones((5, 5), dtype=torch.float16, device="cuda").requires_grad_()
         assert input.is_leaf
         with op_tools.OpDtypeCast():
-            input = torch.ones(
-                (5, 5), dtype=torch.float16, device="cuda"
-            ).requires_grad_()
+            input = torch.ones((5, 5), dtype=torch.float16, device="cuda").requires_grad_()
             assert input.is_leaf
-            weight = torch.ones(
-                (5, 5), dtype=torch.float16, device="cuda"
-            ).requires_grad_()
+            weight = torch.ones((5, 5), dtype=torch.float16, device="cuda").requires_grad_()
             output = torch.nn.functional.linear(input, weight)
             label = torch.ones_like(output)
             output.backward(label)

--- a/op_tools/test/test_opname_match.py
+++ b/op_tools/test/test_opname_match.py
@@ -17,12 +17,8 @@ class TestOpNameMatch(unittest.TestCase):
         self.assertEqual(is_opname_match("torch.addc", "torch.addc,torch.sub"), True)
         self.assertEqual(is_opname_match("torch.addc", "torch.add,torch.sub"), False)
         self.assertEqual(is_opname_match("torch.sub", "torch.addc,torch.sub"), True)
-        self.assertEqual(
-            is_opname_match("torch.sub", "torch.addc,torch.subc,torch.mul"), False
-        )
-        self.assertEqual(
-            is_opname_match("torch.subc", "torch.addc,torch.sub,torch.mul"), False
-        )
+        self.assertEqual(is_opname_match("torch.sub", "torch.addc,torch.subc,torch.mul"), False)
+        self.assertEqual(is_opname_match("torch.subc", "torch.addc,torch.sub,torch.mul"), False)
         self.assertEqual(is_opname_match("torch.subc", ".*"), True)
         self.assertEqual(is_opname_match("torch.subc", "torch.add,.*"), True)
         self.assertEqual(is_opname_match("torch.subc", None), True)
@@ -44,9 +40,7 @@ class TestOpNameMatch(unittest.TestCase):
         self.assertEqual(is_view_op("torch.Tensor.view"), True)
 
     def test_get_dtype_cast_dict_from_config(self):
-        dtype_cast_dict = get_dtype_cast_dict_form_str(
-            "torch.float32->torch.float16,torch.float64->torch.float16,torch.int64->torch.int32"
-        )
+        dtype_cast_dict = get_dtype_cast_dict_form_str("torch.float32->torch.float16,torch.float64->torch.float16,torch.int64->torch.int32")
         self.assertEqual(
             dtype_cast_dict,
             {

--- a/op_tools/test/test_register_torch_hook.py
+++ b/op_tools/test/test_register_torch_hook.py
@@ -1,0 +1,95 @@
+import torch
+import ditorch
+import unittest
+
+
+device = torch.device("cuda")
+
+
+class TestRegisterHook(unittest.TestCase):
+    def test_register_hook_on_linear(self):
+        func = torch.nn.functional.linear
+        input = torch.randn(20, 30, requires_grad=True).to(device)
+        weight = torch.randn(40, 30, requires_grad=True, device=device)
+        bias = torch.randn(40, requires_grad=True, device=device)
+        assert not input.is_leaf
+        assert weight.is_leaf
+        assert bias.is_leaf
+        output = func(input, weight, bias)
+        grad_output = None
+
+        def pre_hook(grad_outputs):
+            print(f"pre hook:{len(grad_outputs)}")
+            nonlocal grad_output
+            grad_output = grad_outputs
+
+        input.grad_fn.register_prehook(pre_hook)
+
+        def post_hook(grad_inputs, grad_outputs):
+            print(f"post hook:{len(grad_inputs)}")
+            print(f"post hook:{len(grad_outputs)}")
+            pass
+
+        input.grad_fn.register_hook(post_hook)
+        # weight.grad_fn.register_hook(post_hook) # grad_fn is None beacuse weight is a leaf
+        assert weight.grad_fn is None
+
+        weitht_grad = None
+        bias_grad = None
+        input_grad = None
+
+        def weitht_tensor_hook(grad):
+            print("weight grad")
+            nonlocal weitht_grad
+            weitht_grad = grad
+
+        def bias_tensor_hook(grad):
+            print("bias grad")
+            nonlocal bias_grad
+            bias_grad = grad
+
+        def input_tensor_hook(grad):
+            print("input grad")
+            nonlocal input_grad
+            input_grad = grad
+
+        input.register_hook(input_tensor_hook)
+        weight.register_hook(weitht_tensor_hook)
+        bias.register_hook(bias_tensor_hook)
+
+        output.backward(torch.ones_like(output))
+        assert grad_output is not None
+        assert weitht_grad is not None
+        assert bias_grad is not None
+        assert input_grad is not None
+        assert torch.allclose(grad_output[0], input_grad)
+        assert torch.allclose(weight.grad, weitht_grad)
+        assert torch.allclose(bias.grad, bias_grad)
+        # assert torch.allclose(input.grad, input_grad) # input.grad is None
+
+    def test_reister_tensor_hook_on_inplace_op(self):
+        x = torch.randn(20, 30, requires_grad=True, device=device)
+        y = torch.randn(20, 30, requires_grad=True, device=device)
+        a = torch.add(x, y) * 2
+        b = torch.sub(a, y) / 3
+        c = torch.mul(b, a) + 1
+        d = torch.div(c, b) - 2
+
+        def get_hook_with_label(label):
+            def input_tensor_hook(grad):
+                print(f"{label} got grad")
+
+            return input_tensor_hook
+
+        x.register_hook(get_hook_with_label("x"))
+        y.register_hook(get_hook_with_label("y"))
+        a.register_hook(get_hook_with_label("a"))
+        b.register_hook(get_hook_with_label("b"))
+        c.register_hook(get_hook_with_label("c"))
+        d.register_hook(get_hook_with_label("d"))
+
+        d.backward(torch.ones_like(d))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/op_tools/test/test_run_op_from_data.py
+++ b/op_tools/test/test_run_op_from_data.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import shutil
 
 
 def run_command_in_sub_process(commands):
@@ -17,14 +16,9 @@ def run_command_in_sub_process(commands):
 
 if __name__ == "__main__":
     raw_data_dir = "op_tools_results"
-    test_data_dir = "op_tools_results_test"
-    shutil.copytree(raw_data_dir, test_data_dir, dirs_exist_ok=True)
 
-    commands = f"python op_tools/run_op_from_data.py {test_data_dir} --sync_time_measure --run_times 10"
+    commands = f"python op_tools/run_op_from_data.py {raw_data_dir} --sync_time_measure --run_times 10"
     run_command_in_sub_process(commands)
 
-    commands = f"python op_tools/run_op_from_data.py {test_data_dir} --sync_time_measure --run_times 2 --acc_check"
+    commands = f"python op_tools/run_op_from_data.py {raw_data_dir} --sync_time_measure --run_times 2 --acc_check"
     run_command_in_sub_process(commands)
-
-    shutil.rmtree(raw_data_dir)
-    shutil.move(test_data_dir, raw_data_dir)

--- a/op_tools/utils.py
+++ b/op_tools/utils.py
@@ -140,9 +140,51 @@ VIEW_OPS = [
     "torch.Tensor.values",
 ]
 
+RANDOM_NUMBER_GEN_OPS = [
+    "torch.Tensor.random_",
+    "torch.Tensor.uniform_",
+    "torch.Tensor.normal_",
+    "torch.Tensor.bernoulli_",
+    "torch.Tensor.poisson_",
+    "torch.Tensor.multinomial_",
+    "torch.Tensor.random",
+    "torch.Tensor.uniform",
+    "torch.Tensor.normal",
+    "torch.Tensor.bernoulli",
+    "torch.Tensor.poisson",
+    "torch.Tensor.multinomial",
+    "torch.rand",
+    "torch.randperm",
+    "torch.bernoulli",
+    "torch.poisson",
+    "torch.randint_like",
+    "torch.randint",
+    "torch.randn",
+    "torch.randn_like",
+    "torch.multinomial",
+    "torch.nn.init.kaiming_uniform",
+    "torch.nn.init.kaiming_uniform_",
+    "torch.nn.init.trunc_normal_",
+    "torch.nn.init.uniform",
+    "torch.nn.init.normal",
+    "torch.nn.init.uniform_",
+    "torch.nn.init.normal_",
+    "torch.nn.init.warnings",
+    "torch.nn.init.xavier_normal",
+    "torch.nn.init.xavier_normal_",
+    "torch.nn.init.xavier_uniform",
+    "torch.nn.init.kaiming_normal",
+    "torch.nn.init.xavier_uniform_",
+    "torch.nn.init.kaiming_normal_",
+]
+
 
 def is_view_op(name):
     return name in VIEW_OPS
+
+
+def is_random_number_gen_op(name):
+    return name in RANDOM_NUMBER_GEN_OPS
 
 
 def tensor_max_diff(a, b):

--- a/op_tools/utils.py
+++ b/op_tools/utils.py
@@ -154,6 +154,7 @@ RANDOM_NUMBER_GEN_OPS = [
     "torch.Tensor.poisson",
     "torch.Tensor.multinomial",
     "torch.rand",
+    "torch.rand_like",
     "torch.randperm",
     "torch.bernoulli",
     "torch.poisson",


### PR DESCRIPTION
增强和重构autocompare： 以统一的方式获取算子反向梯度，修复原先一个tensor同时是多个算子输入时梯度获取不正确的问题
模块化OpAutoCompareHook， 将一个大函数按功能拆到不同的成员函数里
修复部分代码lint问题