### PR TITLE
fix autocompare untyped_strorage bug

### DIFF
--- a/op_tools/test/test_untyped_storage.py
+++ b/op_tools/test/test_untyped_storage.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2024, DeepLink.
+import torch
+import ditorch
+import op_tools
+
+import unittest
+
+
+class TestOpToolWithSpecialOp(unittest.TestCase):
+
+    def test_untyped_storage(self):
+        with op_tools.OpAutoCompare():
+            x = torch.randn(3, 4, 5, dtype=torch.float32, device="cuda")
+            y = x.untyped_storage()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/op_tools/utils.py
+++ b/op_tools/utils.py
@@ -14,11 +14,14 @@ def traverse_container(container):
     elif isinstance(container, (list, tuple, set)):
         for item in container:
             yield from traverse_container(item)
-    elif type(container).__module__.startswith("torch.return_types"):
-        for i in range(len(container)):
-            yield container[i]
-    else:
+    elif isinstance(container, (int, float, str, bool, str)):
         yield container
+    else:
+        try:
+            for i in range(len(container)):
+                yield container[i]
+        except Exception as e:  # noqa: F841
+            yield container
 
 
 def is_cpu_op(*args, **kwargs):


### PR DESCRIPTION
pytorch中有些函数的返回值的类型是torch.return_type, torch.UntypeStorage等，做精度对比等需要对值做处理时，容易漏掉这种特殊的情况。所有这里用一种更通用更抽象的方式去迭代这类返回值。把这类值当成一种容器，用yeild去迭代