### PR TITLE
Add a check to see if the operator input has been modified

### DIFF
--- a/op_tools/op_autocompare_hook.py
+++ b/op_tools/op_autocompare_hook.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 from .save_op_args import save_op_args, serialize_args_to_dict
 
-from .pretty_print import pretty_print_op_args, dict_data_list_to_table
+from .pretty_print import pretty_print_op_args, dict_data_list_to_table, packect_data_to_dict_list
 
 
 SKIP_LIST_OPS = []
@@ -69,7 +69,7 @@ class BackwardHookHandle:
 
         def grad_fun(grad_inputs, grad_outputs):
             self.compare_hook.run_backward_on_cpu(grad_inputs, grad_outputs)
-            self.compare_hook.compare_all_grad()
+            self.compare_hook.compare_backward_relate()
             hook_handle.remove()
 
         hook_handle = tensor.grad_fn.register_hook(grad_fun)
@@ -136,6 +136,7 @@ class OpAutoCompareHook(BaseHook):
             )
 
     def run_backward_on_cpu(self, grad_inputs, grad_output):
+        self.op_backward_args_to_table(grad_inputs, grad_output)
         self.grad_outputs_cpu = to_device("cpu", grad_output, dtype_cast_dict=self.dtype_cast_dict, detach=True)
         self.grad_inputs_cpu = to_device("cpu", grad_inputs, dtype_cast_dict=self.dtype_cast_dict, detach=True)
         for arg_cpu in traverse_container(self.args_cpu):
@@ -164,22 +165,42 @@ class OpAutoCompareHook(BaseHook):
                     self.backward_hook_handle.register_grad_fn_hook(result)
 
     def compare_forward_result(self):
-        compare_info = compare_result(self.name, self.result_device, self.result_cpu)
+        compare_info = compare_result(self.name + " output", self.result_device, self.result_cpu)
         compare_result_cache.append(self.forward_op_id, compare_info)
 
-        allclose = compare_info["allclose"]
-        self.forward_allclose = allclose
-        if not allclose:
-            pretty_print_op_args(
-                self.name,
-                serialize_args_to_dict(*self.args, **self.kwargs),
-                serialize_args_to_dict(self.result),
-            )
-            self.save_forward_args()
+        self.forward_allclose = compare_info["allclose"]
+        compare_info["forward_id"] = self.forward_op_id
+        return compare_info
 
     def compare_inputs(self):
         compare_info = compare_result(self.name + " input", self.args, self.args_cpu)
         compare_result_cache.append(self.forward_op_id, compare_info)
+        compare_info["forward_id"] = self.forward_op_id
+        self.input_allclose = compare_info["allclose"]
+        return compare_info
+
+    def compare_forward_relate(self):
+        input_compare_result = self.compare_inputs()
+        output_compare_result = self.compare_forward_result()
+
+        result_list = input_compare_result["result_list"] + output_compare_result["result_list"]
+        print("\n" * 2)
+        self.pretty_print_op_forward_args()
+        print(dict_data_list_to_table(result_list))
+        print("\n" * 2)
+
+        self.forward_allclose = self.forward_allclose and self.input_allclose
+        if not self.forward_allclose:
+            self.save_forward_args()
+
+    def pretty_print_op_forward_args(self):
+        pretty_print_op_args(self.name, serialize_args_to_dict(*self.args, **self.kwargs), serialize_args_to_dict(self.result))
+
+    def op_backward_args_to_table(self, grad_inputs, grad_output):
+        grad_inputs_list = packect_data_to_dict_list(self.name, serialize_args_to_dict(grad_inputs), "grad_inputs")
+        grad_output_list = packect_data_to_dict_list(self.name, serialize_args_to_dict(grad_output), "grad_output")
+        self.backward_args_table = dict_data_list_to_table(grad_output_list + grad_inputs_list)
+        return self.backward_args_table
 
     def count_params_with_requires_grad(self):
         count = 0
@@ -188,13 +209,27 @@ class OpAutoCompareHook(BaseHook):
                 count = count + 1
         return count
 
-    def compare_all_grad(self):
+    def compare_input_grad(self):
         self.args_grad = self.grad_inputs_cpu
         compare_info = compare_result(self.name + " grad", self.args_cpu_grad, self.args_grad)
+        compare_info["forward_id"] = self.forward_op_id
+        print(dict_data_list_to_table(compare_info["result_list"]))
 
         compare_result_cache.append(self.forward_op_id, compare_info)
 
-        if not compare_info["allclose"]:
+        self.backward_allclose = compare_info["allclose"]
+
+        return compare_info
+
+    def compare_backward_relate(self):
+        backward_compare_result = self.compare_input_grad()
+
+        print("\n" * 2)
+        print(self.backward_args_table)
+        print(dict_data_list_to_table(backward_compare_result["result_list"]))
+        print("\n" * 2)
+
+        if not self.backward_allclose:
             # Parameters are not saved when forward accuracy is normal
             if self.forward_allclose:
                 self.save_forward_args()
@@ -255,18 +290,16 @@ class OpAutoCompareHook(BaseHook):
         with DisableHookGuard():
             self.run_forward_on_cpu()
 
-            self.compare_inputs()
-
-            if self.result is None and self.result_cpu is None:
-                print(f"{self.name} output is None, no check for accuracy")
-                return
-
-            self.compare_forward_result()
-
             self.register_backward_hook_for_grads()
+
+            self.compare_forward_relate()
 
             self.args = to_device("cpu", self.args, detach=True)
             self.kwargs = to_device("cpu", self.kwargs or {}, detach=True)
+
+            if self.result is None and self.result_cpu is None:
+                print(f"{self.name} output is None, no check for backward accuracy")
+                return
 
     def is_should_apply(self, *args, **kwargs):
         if is_random_number_gen_op(self.name):

--- a/op_tools/test/test_compare_result.py
+++ b/op_tools/test/test_compare_result.py
@@ -145,6 +145,13 @@ class TestCompareResult(unittest.TestCase):
             self.assertTrue(math.isnan(compare_info["max_relative_diff"]))
             self.assertTrue(isinstance(compare_info["result_list"], list))
 
+    def test_compare_invalid_input(self):
+        compare_result("empty_list", [], [])  # 输入空列表
+        compare_result("empty_tesnsor", torch.empty(0).cuda(), torch.empty(0).cuda())  # 输入空张量
+        compare_result("invalid_type", (), [])  # 输入元组
+        compare_result("invalid_value_a", ["1", 2, 3], [1, 2, 3])  # 输入a的元素类型不符合要求
+        compare_result("invalid_value_b", [1, 2, 3], ["1", 2, 3])  # 输入b的元素类型不符合要求
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/op_tools/test/test_tool_with_special_op.py
+++ b/op_tools/test/test_tool_with_special_op.py
@@ -82,15 +82,21 @@ class TestOpToolWithSpecialOp(unittest.TestCase):
 
     def test_contiguous(self):
         with op_tools.OpAutoCompare():
-            x = torch.randn(3, 4, 5, dtype=torch.float32, device="cuda")
-            x = x.contiguous()
-
-            y = torch.randn(3, 4, 5, dtype=torch.float64, device="cuda")
+            x = torch.randn(3, 4, 5, dtype=torch.float32, device="cuda", requires_grad=True)
             y = x.contiguous()
+            z = y + y
+            z.backward(torch.ones_like(z))
 
-            z = torch.randn(3, 3, dtype=torch.float64, device="cuda")
-            z = torch.as_strided(input=z, size=(2, 2), stride=(1, 2))
-            z = z.contiguous()
+            x = torch.randn(3, 4, 5, dtype=torch.float64, device="cuda", requires_grad=True)
+            y = x.contiguous()
+            z = y + y
+            z.backward(torch.ones_like(z))
+
+            x = torch.randn(3, 3, dtype=torch.float64, device="cuda", requires_grad=True)
+            x = torch.as_strided(input=z, size=(2, 2), stride=(1, 2))
+            y = x.contiguous()
+            z = y + y
+            z.backward(torch.ones_like(z))
 
 
 if __name__ == "__main__":

--- a/op_tools/test/test_tool_with_special_op.py
+++ b/op_tools/test/test_tool_with_special_op.py
@@ -62,6 +62,24 @@ class TestOpToolWithSpecialOp(unittest.TestCase):
         for i in range(len(value_list)):
             self.assertTrue(value_list[i] == x.shape[i])
 
+    def test_setitem(self):
+        with op_tools.OpAutoCompare():
+            x = torch.randn(3, 4, 5, dtype=torch.float32, device="cuda")
+            x[0, 0, 0] = 1.0  # __setitem__  return None
+
+    def test_inplace_op(self):
+        with op_tools.OpAutoCompare():
+            m = torch.randn(3, 4, 5, dtype=torch.float32, device="cuda", requires_grad=True)
+            x = m + 1
+            x.add_(1.0)
+            x.mul_(2.0)
+            x.sub_(1.0)
+            x.div_(2.0)
+            x.pow_(2.0)
+            x.sqrt_()
+            y = x.abs()
+            y.backward(torch.ones_like(x))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/op_tools/test/test_tool_with_special_op.py
+++ b/op_tools/test/test_tool_with_special_op.py
@@ -80,6 +80,18 @@ class TestOpToolWithSpecialOp(unittest.TestCase):
             y = x.abs()
             y.backward(torch.ones_like(x))
 
+    def test_contiguous(self):
+        with op_tools.OpAutoCompare():
+            x = torch.randn(3, 4, 5, dtype=torch.float32, device="cuda")
+            x = x.contiguous()
+
+            y = torch.randn(3, 4, 5, dtype=torch.float64, device="cuda")
+            y = x.contiguous()
+
+            z = torch.randn(3, 3, dtype=torch.float64, device="cuda")
+            z = torch.as_strided(input=z, size=(2, 2), stride=(1, 2))
+            z = z.contiguous()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/op_tools/utils.py
+++ b/op_tools/utils.py
@@ -4,7 +4,6 @@ import re
 import importlib
 import math
 import os
-from .pretty_print import dict_data_list_to_table
 
 
 def traverse_container(container):
@@ -328,7 +327,6 @@ def compare_result(name, a, b):  # noqa: C901
                 "error_info": error_info_i,
             }
         )
-    print(dict_data_list_to_table(result_list))
 
     return {
         "allclose": allclose,

--- a/op_tools/utils.py
+++ b/op_tools/utils.py
@@ -244,7 +244,7 @@ def get_error_tolerance(dtype, op_name):
 def compare_result(name, a, b):  # noqa: C901
     a_list = []
     b_list = []
-    allclose, max_abs_diff, max_relative_diff, error_info = True, 0, 0, ""
+    allclose, max_abs_diff, max_relative_diff, error_info, atol, rtol = True, 0, 0, "", 0, 0
     for item in traverse_container(a):
         a_list.append(item)
     for item in traverse_container(b):
@@ -280,15 +280,19 @@ def compare_result(name, a, b):  # noqa: C901
                 b_item = b_item.to(a_item.dtype)
             if a_item.shape == b_item.shape:
                 atol, rtol = get_error_tolerance(a_item.dtype, name)
-                max_abs_diff_i, max_relative_diff_i = tensor_max_diff(a_item, b_item)
-                allclose_i = tensor_allclose(a_item, b_item, atol=atol, rtol=rtol)
+                if a_item.numel() > 0:
+                    max_abs_diff_i, max_relative_diff_i = tensor_max_diff(a_item, b_item)
+                    allclose_i = tensor_allclose(a_item, b_item, atol=atol, rtol=rtol)
+                else:
+                    max_abs_diff_i, max_relative_diff_i = 0.0, 0.0
+                    allclose_i = True
             else:
                 error_info_i = f"Inconsistent shape: {a_item.shape} {b_item.shape}"
                 max_abs_diff_i = float("nan")
                 max_relative_diff_i = float("nan")
                 allclose_i = False
 
-        elif type(a) != type(b):  # noqa: E721
+        elif type(a_item) != type(b_item):  # noqa: E721
             error_info_i = f"Inconsistent types: {type(a)} {type(b)}"
             max_abs_diff_i = float("nan")
             max_relative_diff_i = float("nan")
@@ -307,6 +311,15 @@ def compare_result(name, a, b):  # noqa: C901
             max_relative_diff_i = max_abs_diff_i / (abs(a_item) + 1e-6)
             if not allclose_i:
                 error_info_i = f" value: {a_item} {b_item} "
+        else:
+            try:
+                allclose_i = a_item == b_item
+            except Exception as e:
+                allclose_i = False
+                error_info_i = str(e)
+            error_info_i += f"{type(a_item)} {a_item} {type(b_item)} {b_item}"
+            max_abs_diff_i = float("nan")
+            max_relative_diff_i = float("nan")
         if len(a_list) > 1:
             prefex = f" {i}th "
         else:

--- a/op_tools/utils.py
+++ b/op_tools/utils.py
@@ -276,6 +276,9 @@ def compare_result(name, a, b):  # noqa: C901
             max_abs_diff_i = 0
             max_relative_diff_i = 0
         elif isinstance(a_item, torch.Tensor) and isinstance(b_item, torch.Tensor):
+            if a_item.dtype != b_item.dtype:
+                error_info_i += f"Inconsistent dtypes: {a_item.dtype} {b_item.dtype}"
+                b_item = b_item.to(a_item.dtype)
             if a_item.shape == b_item.shape:
                 atol, rtol = get_error_tolerance(a_item.dtype, name)
                 max_abs_diff_i, max_relative_diff_i = tensor_max_diff(a_item, b_item)
@@ -285,8 +288,6 @@ def compare_result(name, a, b):  # noqa: C901
                 max_abs_diff_i = float("nan")
                 max_relative_diff_i = float("nan")
                 allclose_i = False
-            if a_item.dtype != b_item.dtype:
-                error_info_i += f"Inconsistent dtypes: {a_item.dtype} {b_item.dtype}"
 
         elif type(a) != type(b):  # noqa: E721
             error_info_i = f"Inconsistent types: {type(a)} {type(b)}"


### PR DESCRIPTION
1. 增加对算子输入是否被意外修改的检查
Add a check to see if the operator input has been accidentally modified
2. 算子数据类型不一致但是值一致时不再保存最小复现（有些设备上float64强制用float32计算）
3. 修复跑模型时报向None type 没有register_hook的bug: 叶子节点的梯度可以不用注册hook来获取梯度
4. 打印的信息更加简洁明了，算子直接能互相隔开
![截屏2024-09-27 下午4 10 03](https://github.com/user-attachments/assets/ab59d720-ace3-4f48-8491-b23359a2e354)
![截屏2024-09-27 下午4 42 16](https://github.com/user-attachments/assets/9a76a3b5-17ed-4ecb-a110-9ce6d9a68d6b)

