### PR TITLE
Supports printing of the user-level calling code of the current op

### DIFF
--- a/op_tools/base_hook.py
+++ b/op_tools/base_hook.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024, DeepLink.
 from abc import ABC
-from .utils import is_cpu_op
+from .utils import is_cpu_op, current_location
 
 
 def is_should_apply_hook(name, func, *args, **kwargs):
@@ -96,6 +96,7 @@ class BaseHook(ABC):
             and is_should_apply_hook(self.name, self.func, *args, **kwargs)
             and self.is_should_apply(*args, **kwargs)
         ):
+            self.current_location = current_location(name=self.name, print_stack=False)
             if self.name not in self.applied_op:
                 self.applied_op.add(self.name)
                 print(f"apply {self.class_name()} on {self.name}")

--- a/op_tools/op_autocompare_hook.py
+++ b/op_tools/op_autocompare_hook.py
@@ -190,6 +190,7 @@ class OpAutoCompareHook(BaseHook):
             dtype_cast_info = f"cpu_dtype_cast_info(from:to): {self.dtype_cast_dict}"
         print("\n" * 2)
         print(f"{self.name} forward_id: {self.forward_op_id}    {dtype_cast_info}")
+        print(f"{self.current_location}")
         print(self.op_forward_args_to_table())
         print(dict_data_list_to_table(result_list))
         print("\n" * 2)
@@ -241,6 +242,7 @@ class OpAutoCompareHook(BaseHook):
 
         print("\n" * 2)
         print(f"{self.name} forward_id: {self.forward_op_id}    {dtype_cast_info}")
+        print(f"{self.current_location}")
         print(self.backward_args_table)
         print(dict_data_list_to_table(backward_compare_result["result_list"]))
         print("\n" * 2)

--- a/op_tools/op_dispatch_watch_hook.py
+++ b/op_tools/op_dispatch_watch_hook.py
@@ -19,7 +19,11 @@ class OpDispatchWatcherHook(BaseHook):
             inputs_list = packect_data_to_dict_list(self.name + " inputs", serialize_args_to_dict(*self.args, **self.kwargs))
             output_list = packect_data_to_dict_list(self.name + " outputs", serialize_args_to_dict(self.result))
             forward_args_table = dict_data_list_to_table(inputs_list + output_list)
+            print("\n" * 2)
+            print(f"{self.name}  {self.id}")
+            print(f"{self.current_location}")
             print(forward_args_table)
+            print("\n" * 2)
 
     def is_should_apply(self, *args, **kwargs):
         if is_opname_match(self.name, os.getenv("OP_DISPATCH_WATCH_DISABLE_LIST", "")):

--- a/op_tools/op_time_measure_hook.py
+++ b/op_tools/op_time_measure_hook.py
@@ -140,6 +140,7 @@ class OpTimeMeasureHook(BaseHook):
                 "unit": "ms",
             }
             print("\n" * 2)
+            print(self.current_location)
             print(forward_args_table)
             print(dict_data_list_to_table([elasped_info_dict]))
             print("\n" * 2)

--- a/op_tools/test/test_current_location.py
+++ b/op_tools/test/test_current_location.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024, DeepLink.
+from op_tools.utils import current_location
+
+import unittest
+
+
+class TestCurrentLocation(unittest.TestCase):
+
+    def test_current_location(self):
+        def f1():
+            def f2():
+                def f3():
+                    return current_location(stack_depth=-2, print_stack=True)
+
+                return f3()
+
+            return f2()
+
+        location = f1()
+        print(f"location: {location}")
+        self.assertTrue(isinstance(location, str))
+        self.assertTrue("f3" in location)
+        self.assertTrue(__file__ in location)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/op_tools/test/test_pretty_print.py
+++ b/op_tools/test/test_pretty_print.py
@@ -20,6 +20,10 @@ class TestPrettyPrint(unittest.TestCase):
 
         table = dict_data_list_to_table(data_list)
 
+        csv_str = table.get_csv_string()
+
+        print(csv_str)
+
         print(table)
 
 

--- a/op_tools/test/test_tool_with_special_op.py
+++ b/op_tools/test/test_tool_with_special_op.py
@@ -122,6 +122,12 @@ class TestOpToolWithSpecialOp(unittest.TestCase):
         with op_tools.OpTimeMeasure():
             f()
 
+    def test_exp(self):
+        with op_tools.OpAutoCompare():
+            x = torch.randn(3, 4, 5, dtype=torch.float16, device="cuda", requires_grad=True)
+            y = x.exp()
+            y.backward(torch.ones_like(y))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
背景：
当精度对比或者耗时测量时，无法知道用户调用代码。该pr通过traceback包，把当前做精度对比或者耗时测量的算子的调用位置和代码打印出来，方便问题分析。

支持精度对比和算子耗时测量时打印当前算子的用户层调用代码
Supports printing of the user-level calling code of the current operator during accuracy comparison and time-consuming measurement
![截屏2024-09-30 下午4 05 55](https://github.com/user-attachments/assets/8e45fb22-5a05-48a9-bbda-ed26c5c1103c)

![截屏2024-09-30 下午2 29 55](https://github.com/user-attachments/assets/fb05d244-7f7e-43d1-a848-8e21257e4aa1)
![截屏2024-09-30 下午3 29 25](https://github.com/user-attachments/assets/0410baac-e482-4ef0-932a-bdb94c8b0904)
![截屏2024-09-30 下午2 40 13](https://github.com/user-attachments/assets/086688e6-c7c5-44fd-95ef-bda6ee9fc131)
![截屏2024-09-30 下午2 39 55](https://github.com/user-attachments/assets/81255db2-66d4-471e-87f9-738570453f78)
![截屏2024-09-30 下午2 34 43](https://github.com/user-attachments/assets/aab73d26-533a-43b9-9829-2d4af2c4e02a)
![截屏2024-09-30 下午2 34 04](https://github.com/user-attachments/assets/193f40f7-051a-4829-bba5-492818357f09)
![截屏2024-09-30 下午2 32 48](https://github.com/user-attachments/assets/9e6a66c5-5a78-4f08-8166-5ff81b4d7f7b)
