### PR TITLE
Fixed the issue where autocompare reports input is modified in situations like torch.exp(x, out=x)

### DIFF
--- a/op_tools/op_autocompare_hook.py
+++ b/op_tools/op_autocompare_hook.py
@@ -148,8 +148,11 @@ class OpAutoCompareHook(BaseHook):
             dtype_cast_dict=self.dtype_cast_dict,
             detach=True,
         )
+        if self.kwargs.get("out", None) is not None and self.kwargs["out"] in self.args and isinstance(self.kwargs["out"], torch.Tensor):
+            self.kwargs_cpu["out"] = self.args_cpu[self.args.index(self.kwargs["out"])]
+
         # RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
-        if (is_inplace_op(self.name) or self.kwargs.get("inplace", False) or is_view_op(self.name)) and self.args[0].requires_grad:
+        if (is_inplace_op(self.name, *self.args, **self.kwargs) or is_view_op(self.name)) and self.args[0].requires_grad:
             args_cpu = [item for item in self.args_cpu]
             args_cpu[0] = args_cpu[0].clone()
             self.args_cpu = tuple(args_cpu)

--- a/op_tools/pretty_print.py
+++ b/op_tools/pretty_print.py
@@ -43,6 +43,10 @@ def packect_data_to_dict_list(op_name, inputs_dict):
         elif isinstance(arg, (str, int, float, bool)):
             data_dict_list.append({"name": op_name + (f"[{arg_index}]" if len(args) > 1 else ""), "value": arg})
     for key, value in kwargs.items():
-        data_dict_list.append({"name": op_name + f" {key}", "value": value})
+        if isinstance(value, dict):
+            value.update({"name": op_name + f" {key}"})
+            data_dict_list.append(value)
+        else:
+            data_dict_list.append({"name": op_name + f" {key}", "value": value})
 
     return data_dict_list

--- a/op_tools/test/test_tool_with_special_op.py
+++ b/op_tools/test/test_tool_with_special_op.py
@@ -196,6 +196,11 @@ class TestOpToolWithSpecialOp(unittest.TestCase):
         x = torch.tensor(0, dtype=torch.int32, device="cuda")
         self.assertTrue(x.device.type == "cuda")
 
+    def test_input_is_output(self):
+        with op_tools.OpAutoCompare():
+            x = torch.randn(3, 4, 5, dtype=torch.float32, device="cuda", requires_grad=False)
+            torch.exp(x, out=x)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/op_tools/utils.py
+++ b/op_tools/utils.py
@@ -125,7 +125,11 @@ def is_opname_match(name, op_pattern=None):
     return False
 
 
-def is_inplace_op(name):
+def is_inplace_op(name, *args, **kwargs):
+    if kwargs.get("out", None) is not None and isinstance(kwargs["out"], torch.Tensor) and kwargs["out"] in args:
+        return True
+    if kwargs.get("inplace", False):
+        return True
     INPLACES_OP = ["torch.Tensor.__setitem__", "torch.Tensor.to", "torch.Tensor.contiguous", "torch.Tensor.to"]
     return name in INPLACES_OP or (name.endswith("_") and (not name.endswith("__")) and (name.startswith("torch.Tensor.")))
 


### PR DESCRIPTION
torch.exp(x, out=x) 这种用法下，实际是个inplace 操作。autocompare会对输入做检查，会检查算子算完后输入是否被错误的修改。如果是这种情况下，原先会报输入被修改，同时会保存相关的checkpoint。现在修复了该问题
```
autocompare    torch.exp forward_id: 1    
/deeplink_afs/zhaoguochun/ditorch2/op_tools/test/test_tool_with_special_op.py:202 test_input_is_output: torch.exp(x, out=x)
+---------------------------+--------+---------+-------+-----------+------------+---------------+---------------+----------------+
|            name           | device |  dtype  | numel |   shape   |   stride   | requires_grad |     layout    |    data_ptr    |
+---------------------------+--------+---------+-------+-----------+------------+---------------+---------------+----------------+
|      torch.exp inputs     | cuda:0 | float32 |   60  | (3, 4, 5) | (20, 5, 1) |     False     | torch.strided | 20067179823104 |
|    torch.exp inputs out   | cuda:0 | float32 |   60  | (3, 4, 5) | (20, 5, 1) |     False     | torch.strided | 20067179823104 |
|     torch.exp outputs     | cuda:0 | float32 |   60  | (3, 4, 5) | (20, 5, 1) |     False     | torch.strided | 20067179823104 |
|   torch.exp inputs(cpu)   |  cpu   | float32 |   60  | (3, 4, 5) | (20, 5, 1) |     False     | torch.strided |   514196288    |
| torch.exp inputs(cpu) out |  cpu   | float32 |   60  | (3, 4, 5) | (20, 5, 1) |     False     | torch.strided |   514196288    |
|   torch.exp outputs(cpu)  |  cpu   | float32 |   60  | (3, 4, 5) | (20, 5, 1) |     False     | torch.strided |   514196288    |
+---------------------------+--------+---------+-------+-----------+------------+---------------+---------------+----------------+
+--------------------------------+----------+-------------------+--------------+-------------------+-------------+-------------+------------+
|              name              | allclose | cosine_similarity | max_abs_diff | max_relative_diff |     atol    |     rtol    | error_info |
+--------------------------------+----------+-------------------+--------------+-------------------+-------------+-------------+------------+
| torch.exp input                |   True   |    0.999999881    | 0.000000477  |    0.000000108    | 0.000010000 | 0.000010000 |            |
| torch.exp output               |   True   |    0.999999881    | 0.000000477  |    0.000000108    | 0.000010000 | 0.000010000 |            |
+--------------------------------+----------+-------------------+--------------+-------------------+-------------+-------------+------------+
```
