### PR TITLE
fix device type mock bug

### DIFF
--- a/ditorch/common_adapter.py
+++ b/ditorch/common_adapter.py
@@ -15,8 +15,11 @@ if torch.__version__ >= "2.0.0":
                 name = None
             result = func(*args, **(kwargs or {}))
             if name == "torch.Tensor.device.__get__":
-                if result.type != "cpu":
-                    result = torch.device("cuda" + (":" + str(result.index)) if result.index is not None else "")
+                if result.type not in ["cpu", "mps", "xpu", "xla", "meta"]:
+                    device_str = "cuda"
+                    if result.index is not None:
+                        device_str += f":{result.index}"
+                    result = torch.device(device_str)
             if name == "torch.Tensor.__repr__":
                 device = args[0].device
                 if device.type != "cpu":

--- a/op_tools/test/test_tool_with_special_op.py
+++ b/op_tools/test/test_tool_with_special_op.py
@@ -196,6 +196,13 @@ class TestOpToolWithSpecialOp(unittest.TestCase):
         x = torch.tensor(0, dtype=torch.int32, device="cuda")
         self.assertTrue(x.device.type == "cuda")
 
+        x = torch.tensor(0, dtype=torch.int32, device="cuda:0")
+        self.assertTrue(x.device.type == "cuda")
+        self.assertTrue(x.device.index == 0)
+
+        x = torch.tensor(0, dtype=torch.int32, device="meta")
+        self.assertTrue(x.device.type == "meta")
+
     def test_input_is_output(self):
         with op_tools.OpAutoCompare():
             x = torch.randn(3, 4, 5, dtype=torch.float32, device="cuda", requires_grad=False)


### PR DESCRIPTION
为了让以下测试代码在国产设备上测试通过

```
        x = torch.tensor(0, dtype=torch.int32, device="cuda:0")
        self.assertTrue(x.device.type == "cuda")
        self.assertTrue(x.device.index == 0)
        x = torch.tensor(0, dtype=torch.int32, device="meta")
        self.assertTrue(x.device.type == "meta")
```