### PR TITLE
yb/using div_inp for saving memory when mocking dist ops on npu

### DIFF
--- a/ci/run_individual_test_cases.sh
+++ b/ci/run_individual_test_cases.sh
@@ -1,5 +1,5 @@
 date
-find ditorch op_tools -name test*.py | xargs -I {} bash -c ' echo "start run {}";date;time python {} && echo "Test {} PASSED\n\n\n" || echo "Test {} FAILED\n\n\n"' 2>&1 | tee test_individual_cases.log
+find ditorch op_tools -name "test*.py" | xargs -I {} bash -c ' echo "start run {}";date;time python {} && echo "Test {} PASSED\n\n\n" || echo "Test {} FAILED\n\n\n"' 2>&1 | tee test_individual_cases.log
 
 # Check if any tests failed
 if grep -Eq "FAILED" test_individual_cases.log; then

--- a/ditorch/test/individual/test_utils.py
+++ b/ditorch/test/individual/test_utils.py
@@ -2,11 +2,11 @@
 
 import unittest
 import torch
-from ditorch.utils import is_to_fp32_tensor
+from ditorch.utils import is_to_fp32_tensor, tensor_op_inp
 
 
 @is_to_fp32_tensor(to_fp32=True)
-def test_to_fp32_and_add_1(tensor: torch.Tensor, tensors_list, tensors_dict):
+def to_fp32_and_add_1(tensor: torch.Tensor, tensors_list, tensors_dict):
     assert (
         tensor.dtype == torch.float32
     ), f"tensor's dtype is not fp32, but {tensor.dtype}"
@@ -25,54 +25,73 @@ def test_to_fp32_and_add_1(tensor: torch.Tensor, tensors_list, tensors_dict):
         v.add_(1)
 
 
+def test_is_to_fp32_tensor():
+    tensor = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float16)
+    tensors_list = [
+        torch.tensor([1.0, 1.0, 1.0], dtype=torch.float16),
+        torch.tensor([2.0, 2.0, 2.0], dtype=torch.float16),
+        torch.tensor([3.0, 3.0, 3.0], dtype=torch.float16),
+    ]
+    tensors_dict = {
+        "tensor1": torch.tensor([1.0, 1.0, 1.0], dtype=torch.float16),
+        "tensor2": torch.tensor([2.0, 2.0, 2.0], dtype=torch.float16),
+        "tensor3": torch.tensor([3.0, 3.0, 3.0], dtype=torch.float16),
+    }
+    to_fp32_and_add_1(tensor, tensors_list, tensors_dict)
+    expected_tensor = torch.tensor([2.0, 3.0, 4.0], dtype=torch.float16)
+    expected_tensors_list = [
+        torch.tensor([2.0, 2.0, 2.0], dtype=torch.float16),
+        torch.tensor([3.0, 3.0, 3.0], dtype=torch.float16),
+        torch.tensor([4.0, 4.0, 4.0], dtype=torch.float16),
+    ]
+    expected_tensors_dict = {
+        "tensor1": torch.tensor([2.0, 2.0, 2.0], dtype=torch.float16),
+        "tensor2": torch.tensor([3.0, 3.0, 3.0], dtype=torch.float16),
+        "tensor3": torch.tensor([4.0, 4.0, 4.0], dtype=torch.float16),
+    }
+
+    assert (
+        tensor.dtype == expected_tensor.dtype
+    ), f"tensor's dtype ({tensor.dtype}) is not the same as expected_tensor's ({expected_tensor.dtype})"
+    assert torch.allclose(
+        tensor, expected_tensor
+    ), f"tensor's value ({tensor}) is not the same as expected_tensor's {expected_tensor}."
+
+    for i in range(len(tensors_list)):
+        assert (
+            tensors_list[i].dtype == expected_tensors_list[i].dtype
+        ), f"tensor's dtype ({tensors_list[i].dtype}) is not the same as expected_tensor's ({expected_tensors_list[i].dtype})"
+        assert torch.allclose(
+            tensors_list[i], expected_tensors_list[i]
+        ), f"tensor's value ({tensors_list[i]}) is not the same as expected_tensor's {expected_tensors_list[i]}."
+
+    for k, v in tensors_dict.items():
+        assert (
+            v.dtype == expected_tensors_dict[k].dtype
+        ), f"tensor's dtype ({v.dtype}) is not the same as expected_tensor's ({expected_tensors_dict[k].dtype})"
+        assert torch.allclose(
+            v, expected_tensors_dict[k]
+        ), f"tensor's value ({v}) is not the same as expected_tensor's {expected_tensors_dict[k]}."
+
+
+def test_tensor_op_inp():
+    tensor = torch.tensor([3.0, 3.0, 3.0], dtype=torch.float32)
+    tensor_op_inp(tensor, "div_", 2.0)
+    tensor_expected = torch.Tensor([1.5, 1.5, 1.5])
+    assert torch.allclose(tensor, tensor_expected), f"tensor's value ({tensor}) is not the same as expected_tensor's {tensor_expected}."
+
+    para = torch.nn.Parameter(torch.tensor([3.0, 3.0, 3.0], dtype=torch.float32))
+    tensor_op_inp(para, "div_", 2.0)
+    tensor_expected = torch.Tensor([1.5, 1.5, 1.5])
+    assert torch.allclose(para, tensor_expected), f"tensor's value ({para}) is not the same as expected_tensor's {tensor_expected}."
+
+
 class TestUtils(unittest.TestCase):
     def test_is_to_fp32_tensor(self):
-        tensor = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float16)
-        tensors_list = [
-            torch.tensor([1.0, 1.0, 1.0], dtype=torch.float16),
-            torch.tensor([2.0, 2.0, 2.0], dtype=torch.float16),
-            torch.tensor([3.0, 3.0, 3.0], dtype=torch.float16),
-        ]
-        tensors_dict = {
-            "tensor1": torch.tensor([1.0, 1.0, 1.0], dtype=torch.float16),
-            "tensor2": torch.tensor([2.0, 2.0, 2.0], dtype=torch.float16),
-            "tensor3": torch.tensor([3.0, 3.0, 3.0], dtype=torch.float16),
-        }
-        test_to_fp32_and_add_1(tensor, tensors_list, tensors_dict)
-        expected_tensor = torch.tensor([2.0, 3.0, 4.0], dtype=torch.float16)
-        expected_tensors_list = [
-            torch.tensor([2.0, 2.0, 2.0], dtype=torch.float16),
-            torch.tensor([3.0, 3.0, 3.0], dtype=torch.float16),
-            torch.tensor([4.0, 4.0, 4.0], dtype=torch.float16),
-        ]
-        expected_tensors_dict = {
-            "tensor1": torch.tensor([2.0, 2.0, 2.0], dtype=torch.float16),
-            "tensor2": torch.tensor([3.0, 3.0, 3.0], dtype=torch.float16),
-            "tensor3": torch.tensor([4.0, 4.0, 4.0], dtype=torch.float16),
-        }
+        test_is_to_fp32_tensor()
 
-        assert (
-            tensor.dtype == expected_tensor.dtype
-        ), f"tensor's dtype ({tensor.dtype}) is not the same as expected_tensor's ({expected_tensor.dtype})"
-        assert torch.allclose(
-            tensor, expected_tensor
-        ), f"tensor's value ({tensor}) is not the same as expected_tensor's {expected_tensor}."
-
-        for i in range(len(tensors_list)):
-            assert (
-                tensors_list[i].dtype == expected_tensors_list[i].dtype
-            ), f"tensor's dtype ({tensors_list[i].dtype}) is not the same as expected_tensor's ({expected_tensors_list[i].dtype})"
-            assert torch.allclose(
-                tensors_list[i], expected_tensors_list[i]
-            ), f"tensor's value ({tensors_list[i]}) is not the same as expected_tensor's {expected_tensors_list[i]}."
-
-        for k, v in tensors_dict.items():
-            assert (
-                v.dtype == expected_tensors_dict[k].dtype
-            ), f"tensor's dtype ({v.dtype}) is not the same as expected_tensor's ({expected_tensors_dict[k].dtype})"
-            assert torch.allclose(
-                v, expected_tensors_dict[k]
-            ), f"tensor's value ({v}) is not the same as expected_tensor's {expected_tensors_dict[k]}."
+    def test_tensor_op_inp(self):
+        test_tensor_op_inp()
 
 
 if __name__ == "__main__":

--- a/ditorch/torch_npu_adapter/mock_dist.py
+++ b/ditorch/torch_npu_adapter/mock_dist.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, DeepLink.
 import torch.nn.functional as F  # noqa
 import torch.distributed as dist
-from ditorch.utils import is_to_fp32_tensor, copy_inp
+from ditorch.utils import is_to_fp32_tensor, div_inp
 
 
 def mock_dist(use_fp32=False):
@@ -19,8 +19,7 @@ def mock_dist(use_fp32=False):
                 handle.wait()
             if dst == dist.get_rank(group):
                 world_size = dist.get_world_size(group)
-                tensor_tmp = tensor / world_size
-                copy_inp(tensor, tensor_tmp)
+                div_inp(tensor, world_size)
         else:
             handle = dist_reduce(tensor, op=op, group=group, async_op=async_op)
         return handle
@@ -32,8 +31,7 @@ def mock_dist(use_fp32=False):
             if handle is not None:
                 handle.wait()
             world_size = dist.get_world_size(group)
-            tensor_tmp = tensor / world_size
-            copy_inp(tensor, tensor_tmp)
+            div_inp(tensor, world_size)
         else:
             handle = dist_all_reduce(tensor, op=op, group=group, async_op=async_op)
         return handle
@@ -45,8 +43,7 @@ def mock_dist(use_fp32=False):
             if handle is not None:
                 handle.wait()
             world_size = dist.get_world_size(group)
-            output_tmp = output / world_size
-            copy_inp(output, output_tmp)
+            div_inp(output, world_size)
         else:
             handle = dist__reduce_scatter_base(output, input, op=op, group=group, async_op=async_op)
         return handle


### PR DESCRIPTION
1. using div_inp for saving memory when mocking dist ops on npu
2. fix the errors in the usage of shell `find`  